### PR TITLE
Make show and hide keys optional

### DIFF
--- a/src/interface.vue
+++ b/src/interface.vue
@@ -22,8 +22,12 @@ export default {
           con.conditions.forEach(c => {
             if (c.value === newVal[con.toggle]) {
               this.log("found case!");
-              c.show.forEach(el => this.show(el));
-              c.hide.forEach(el => this.hide(el));
+              if (Array.isArray(c.show)) {
+                c.show.forEach(el => this.show(el));
+              }
+              if (Array.isArray(c.hide)) {
+                c.hide.forEach(el => this.hide(el));
+              }
             } else {
               this.log(c.value + " !== " + newVal[con.toggle]);
             }


### PR DESCRIPTION
This allows to only configure either a hide or show for conditions without having to provide an empty array.