### PR TITLE
update css-Selector

### DIFF
--- a/src/interface.vue
+++ b/src/interface.vue
@@ -35,11 +35,11 @@ export default {
   methods: {
     hide(el) {
       this.log("hide " + el);
-      document.querySelector("[field=" + el + "]").parentElement.parentElement.style.display = "none";
+      document.querySelector(`[field="${el}" ], [fields="${el}"]`).parentElement.parentElement.style.display = "none";
     },
     show(el) {
       this.log("show " + el);
-      document.querySelector("[field=" + el + "]").parentElement.parentElement.style.display = "block";
+      document.querySelector(`[field="${el}" ], [fields="${el}"]`).parentElement.parentElement.style.display = "block";
     },
     log(log) {
       if(this.debug) {


### PR DESCRIPTION
With this fix it's possible to show and hide m2m fields.

Keep in mind: instead of the field-name one has to put into the JSON the fieldnames of the relational fields. (eg. `tableA.id,tableB.id`)
Easiest way to find the right value to put in the JSON is to just look what the html-markup says. :-)